### PR TITLE
manage users permissions through configuration file

### DIFF
--- a/src/Bab/RabbitMq/Command/QueueRemoveCommand.php
+++ b/src/Bab/RabbitMq/Command/QueueRemoveCommand.php
@@ -43,7 +43,7 @@ class QueueRemoveCommand extends BaseCommand
                 continue;
             }
             $output->writeln(sprintf(
-                'Purge queue <comment>%s</comment>.',
+                'Remove queue <comment>%s</comment>.',
                 $queue
             ));
 

--- a/src/Bab/RabbitMq/Command/QueueRemoveCommand.php
+++ b/src/Bab/RabbitMq/Command/QueueRemoveCommand.php
@@ -37,17 +37,26 @@ class QueueRemoveCommand extends BaseCommand
                 $pattern
             ));
         }
-
+        
+        $hasQueueRemoved = false;
         foreach ($vhostManager->getQueues() as $queue) {
             if (null !== $pattern && 1 !== preg_match($pattern, $queue)) {
                 continue;
             }
+            
             $output->writeln(sprintf(
                 'Remove queue <comment>%s</comment>.',
                 $queue
             ));
 
             $vhostManager->remove($queue);
+            
+            $hasQueueRemoved = true;
         };
+        
+        if($hasQueueRemoved === false)
+        {
+            $output->writeln('<info>No queue match the specified pattern</info>.');
+        }
     }
 }

--- a/src/Bab/RabbitMq/VhostManager.php
+++ b/src/Bab/RabbitMq/VhostManager.php
@@ -189,6 +189,10 @@ class VhostManager
                 $this->createBinding($exchange, $bindingName, $routingKey);
             }
         }
+        
+        if (!empty($config['permissions'])) {
+            $this->setPermissions($config['permissions']);
+        }
     }
 
     /**
@@ -321,6 +325,50 @@ class VhostManager
                 'alternate-exchange' => 'unroutable'
             )
         ));
+    }
+    
+    /**
+     * setPermissions
+     *
+     * @param array $permissions
+     *
+     * @return void
+     */
+    protected function setPermissions(array $permissions = array())
+    {
+        if (!empty($permissions)) {
+            foreach($permissions as $user => $userPermissions)
+            {
+                $parameters = $this->extractPermissions($userPermissions);
+                $this->query('PUT', '/api/permissions/'.$this->credentials['vhost'].'/'.$user, $parameters);
+            }
+        }
+    }
+    
+    /**
+     * extractPermissions
+     *
+     * @param array $userPermissions
+     *
+     * @return void
+     */
+    private function extractPermissions(array $userPermissions = array())
+    {
+        $permissions = array(
+            'configure' => '',
+            'read' => '',
+            'write' => '',
+        );
+        
+        if (!empty($userPermissions)) {
+            foreach(array_keys($permissions) as $permission) {
+                if (!empty($userPermissions[$permission])) {
+                    $permissions[$permission] = $userPermissions[$permission];
+                }
+            }
+        }
+        
+        return $permissions;
     }
 
     /**


### PR DESCRIPTION
Add the ability to manage user permissions through the configuration file with new configuration values as follow:

``` yaml
permissions:
        my_user:
            configuration:
            read: .*
            write: .*
```
