### PR TITLE
Feat message sender command

### DIFF
--- a/rabbit
+++ b/rabbit
@@ -1,13 +1,14 @@
 #!/usr/bin/env php
 <?php
 
-(@include_once __DIR__ . '/vendor/autoload.php') || @include_once __DIR__ . '/../../autoload.php';
+(@include_once __DIR__.'/vendor/autoload.php') || @include_once __DIR__.'/../../autoload.php';
 
 use Bab\RabbitMq\Command\VhostMappingCreateCommand;
 use Bab\RabbitMq\Command\QueuePurgeCommand;
 use Bab\RabbitMq\Command\VhostResetCommand;
 use Bab\RabbitMq\Command\QueueRemoveCommand;
 use Bab\RabbitMq\Command\MessageMoveCommand;
+use Bab\RabbitMq\Command\MessageSenderCommand;
 use Symfony\Component\Console\Application;
 
 $application = new Application();
@@ -17,4 +18,5 @@ $application->add(new MessageMoveCommand());
 $application->add(new QueuePurgeCommand());
 $application->add(new QueueRemoveCommand());
 $application->add(new VhostResetCommand());
+$application->add(new MessageSenderCommand());
 $application->run();

--- a/src/Bab/RabbitMq/Command/MessageSenderCommand.php
+++ b/src/Bab/RabbitMq/Command/MessageSenderCommand.php
@@ -23,8 +23,8 @@ class MessageSenderCommand extends BaseCommand
             ->addArgument('to_vhost', InputArgument::REQUIRED, 'To which vhost?')
             ->addArgument('to_exchange', InputArgument::REQUIRED, 'To which exchange?')
             ->addArgument('to_routing_key', InputArgument::REQUIRED, 'To which routing key?')
-            ->addOption('file', 'f', InputOption::VALUE_REQUIRED, 'File containing every JSON Encoded messages to send into rabbit')
-            ->addOption('json_encoded_message', 'm', InputOption::VALUE_REQUIRED, 'JSON Encoded message to send into rabbit (Only available if the file was not filled)')
+            ->addOption('file', 'f', InputOption::VALUE_REQUIRED, 'File containing every messages to send into rabbit')
+            ->addOption('message', 'm', InputOption::VALUE_REQUIRED, 'Message to send into rabbit (Only available if the file was not filled)')
         ;
     }
 
@@ -51,7 +51,7 @@ class MessageSenderCommand extends BaseCommand
         }
 
         if (!$messages) {
-            $encodedMessage = $input->getOption('json_encoded_message');
+            $encodedMessage = $input->getOption('message');
             if (!empty($encodedMessage)) {
                 $messages = array($encodedMessage);
             }

--- a/src/Bab/RabbitMq/Command/MessageSenderCommand.php
+++ b/src/Bab/RabbitMq/Command/MessageSenderCommand.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Bab\RabbitMq\Command;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Swarrot\Broker\Message;
+
+class MessageSenderCommand extends BaseCommand
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('message:sender')
+            ->setDescription('Send messages to a queue')
+            ->addArgument('to_vhost', InputArgument::REQUIRED, 'To which vhost?')
+            ->addArgument('to_exchange', InputArgument::REQUIRED, 'To which exchange?')
+            ->addArgument('to_routing_key', InputArgument::REQUIRED, 'To which routing key?')
+            ->addOption('file', 'f', InputOption::VALUE_REQUIRED, 'File containing every JSON Encoded messages to send into rabbit')
+            ->addOption('json_encoded_message', 'm', InputOption::VALUE_REQUIRED, 'JSON Encoded message to send into rabbit (Only available if the file was not filled)')
+        ;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln(sprintf(
+            'Send messages to exchange "%s" with routingKey "%s" (vhost: "%s")',
+            $input->getArgument('to_exchange'),
+            $input->getArgument('to_routing_key'),
+            $input->getArgument('to_vhost')
+        ));
+
+        $vhostManager = $this->getVhostManager($input, $output, $input->getArgument('to_vhost'));
+
+        $messages = array();
+
+        $file = $input->getOption('file');
+
+        if (null !== $file) {
+            $messages = file($file, FILE_SKIP_EMPTY_LINES);
+        }
+
+        if (!$messages) {
+            $encodedMessage = $input->getOption('json_encoded_message');
+            if (!empty($encodedMessage)) {
+                $messages = array($encodedMessage);
+            }
+        }
+
+        if (!$messages) {
+            throw new \InvalidArgumentException('No message to publish.');
+        }
+
+        $notHandledMessages = array();
+
+        foreach ($messages as $message) {
+            try {
+                $vhostManager->publishMessage(
+                    $input->getArgument('to_exchange'),
+                    $input->getArgument('to_routing_key'),
+                    $message
+                );
+            } catch (\Exception $e) {
+                $notHandledMessages[] = array(
+                    'payload' => $message,
+                    'exception' => $e->getMessage(),
+                );
+
+                continue;
+            }
+
+            $output->writeln(sprintf('Message published: <info>%s</info>', $message));
+        }
+
+        if (count($notHandledMessages)) {
+            $output->writeln(sprintf('<error>- %d message(s) were/was not published into rabbit:</error>', count($notHandledMessages)));
+
+            $tableHelper = $this->getHelperSet()->get('table');
+            $tableHelper
+                ->setHeaders(array('Message', 'Exception'))
+                ->setRows($notHandledMessages)
+            ;
+            $tableHelper->render($output);
+        }
+    }
+}


### PR DESCRIPTION
Add the possibility with a command to send to Rabbit either:
- a single message:

``` bash
./rabbit message:sender -H host -u user -p password vhost exchange routing_key --message="test message"
```
- or multiple messages from a file (every line is considered as a message):

``` bash
./rabbit message:sender -H host -u user -p password vhost exchange routing_key --file="/directory/your_file"
```
