### PR TITLE
Remove the dependency on the symfony/filesystem component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "license": "MIT",
     "require": {
         "symfony/console": "~2.4",
-        "symfony/filesystem": "~2.4",
         "symfony/yaml": "~2.4",
         "swarrot/swarrot": "~2.0"
     },

--- a/src/Bab/RabbitMq/Command/BaseCommand.php
+++ b/src/Bab/RabbitMq/Command/BaseCommand.php
@@ -10,7 +10,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Bab\RabbitMq\Action\RealAction;
 use Bab\RabbitMq\HttpClient\CurlClient;
 use Bab\RabbitMq\Logger\CliLogger;
-use Symfony\Component\Filesystem\Filesystem;
 
 class BaseCommand extends Command
 {
@@ -62,10 +61,8 @@ class BaseCommand extends Command
     protected function getCredentials(InputInterface $input, OutputInterface $output)
     {
         if (null !== $connection = $input->getOption('connection')) {
-            $fs = new Filesystem();
-
             $file = rtrim(getenv('HOME'), '/') . '/.rabbitmq_admin_toolkit';
-            if (!$fs->exists($file)) {
+            if (!file_exists($file)) {
                 throw new \InvalidArgumentException('Can\'t use connection option without a ~/.rabbitmq_admin_toolkit file');
             }
             $credentials = json_decode(file_get_contents($file), true);

--- a/src/Bab/RabbitMq/Command/MessageMoveCommand.php
+++ b/src/Bab/RabbitMq/Command/MessageMoveCommand.php
@@ -13,7 +13,6 @@ use Swarrot\Processor\ProcessorInterface;
 use Swarrot\Broker\Message;
 use Swarrot\Consumer;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Filesystem\Filesystem;
 
 class MessageMoveCommand extends Command
 {
@@ -98,10 +97,8 @@ class MessageMoveCommand extends Command
      */
     public function getChannel($connectionName, $vhost)
     {
-        $fs = new Filesystem();
-
         $file = rtrim(getenv('HOME'), '/') . '/.rabbitmq_admin_toolkit';
-        if (!$fs->exists($file)) {
+        if (!file_exists($file)) {
             throw new \InvalidArgumentException('Can\'t find ~/.rabbitmq_admin_toolkit file');
         }
         $credentials = json_decode(file_get_contents($file), true);

--- a/src/Bab/RabbitMq/Configuration/FromArray.php
+++ b/src/Bab/RabbitMq/Configuration/FromArray.php
@@ -3,8 +3,6 @@
 namespace Bab\RabbitMq\Configuration;
 
 use Bab\RabbitMq\Configuration;
-use Symfony\Component\Yaml\Parser;
-use Symfony\Component\Filesystem\Filesystem;
 
 class FromArray implements Configuration
 {

--- a/src/Bab/RabbitMq/Configuration/Yaml.php
+++ b/src/Bab/RabbitMq/Configuration/Yaml.php
@@ -4,15 +4,13 @@ namespace Bab\RabbitMq\Configuration;
 
 use Bab\RabbitMq\Configuration;
 use Symfony\Component\Yaml\Parser;
-use Symfony\Component\Filesystem\Filesystem;
 
 class Yaml extends FromArray
 {
     public function __construct($filePath)
     {
-        $fs = new Filesystem();
-        if (!$fs->exists($filePath)) {
-            throw new \InvalidArgumentException(sprintf('File "%s" doen\'t exist', $filePath));
+        if (!file_exists($filePath)) {
+            throw new \InvalidArgumentException(sprintf('File "%s" doesn\'t exist', $filePath));
         }
 
         $yaml = new Parser();


### PR DESCRIPTION
Using this component just to check the existence of a file is way overkill. There is no platform inconsistency in file_exists needing to be normalized by the component.
