### PR TITLE
Clean the codebase

### DIFF
--- a/src/Bab/RabbitMq/Action.php
+++ b/src/Bab/RabbitMq/Action.php
@@ -4,15 +4,44 @@ namespace Bab\RabbitMq;
 
 interface Action
 {
-    public function __construct(HttpClient $httpClient);
-
+    /**
+     * @param string $name
+     * @param array  $parameters
+     *
+     * @return void
+     */
     public function createExchange($name, $parameters);
 
+    /**
+     * @param string $name
+     * @param array  $parameters
+     *
+     * @return void
+     */
     public function createQueue($name, $parameters);
 
+    /**
+     * @param string $name
+     * @param string $queue
+     * @param string $routingKey
+     * @param array  $arguments
+     *
+     * @return void
+     */
     public function createBinding($name, $queue, $routingKey, array $arguments = array());
 
+    /**
+     * @param string $user
+     * @param array $parameters
+     *
+     * @return void
+     */
     public function setPermissions($user, array $parameters = array());
 
+    /**
+     * @param string $vhost
+     *
+     * @return void
+     */
     public function setVhost($vhost);
 }

--- a/src/Bab/RabbitMq/Action/Action.php
+++ b/src/Bab/RabbitMq/Action/Action.php
@@ -19,11 +19,21 @@ abstract class Action implements \Bab\RabbitMq\Action
         $this->logger = new NullLogger();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function setVhost($vhost)
     {
         $this->vhost = $vhost;
     }
 
+    /**
+     * @param string     $verb
+     * @param string     $uri
+     * @param array|null $parameters
+     *
+     * @return string
+     */
     protected function query($verb, $uri, $parameters)
     {
         $this->ensureVhostDefined();

--- a/src/Bab/RabbitMq/Action/RealAction.php
+++ b/src/Bab/RabbitMq/Action/RealAction.php
@@ -2,23 +2,31 @@
 
 namespace Bab\RabbitMq\Action;
 
-
 class RealAction extends Action
 {
+    /**
+     * {@inheritDoc}
+     */
     public function createExchange($name, $parameters)
     {
         $this->log(sprintf('Create exchange <info>%s</info>', $name));
 
-        return $this->query('PUT', '/api/exchanges/'.$this->vhost.'/'.$name, $parameters);
+        $this->query('PUT', '/api/exchanges/'.$this->vhost.'/'.$name, $parameters);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function createQueue($name, $parameters)
     {
         $this->log(sprintf('Create queue <info>%s</info>', $name));
 
-        return $this->query('PUT', '/api/queues/'.$this->vhost.'/'.$name, $parameters);
+        $this->query('PUT', '/api/queues/'.$this->vhost.'/'.$name, $parameters);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function createBinding($name, $queue, $routingKey, array $arguments = array())
     {
         $this->log(sprintf(
@@ -36,9 +44,12 @@ class RealAction extends Action
             $parameters['routing_key'] = $routingKey;
         }
 
-        return $this->query('POST', '/api/bindings/'.$this->vhost.'/e/'.$name.'/q/'.$queue, $parameters);
+        $this->query('POST', '/api/bindings/'.$this->vhost.'/e/'.$name.'/q/'.$queue, $parameters);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function setPermissions($user, array $parameters = array())
     {
         $this->log(sprintf('Grant following permissions for user <info>%s</info> on vhost <info>%s</info>: <info>%s</info>', $user, $this->vhost, json_encode($parameters)));

--- a/src/Bab/RabbitMq/Command/MessageSenderCommand.php
+++ b/src/Bab/RabbitMq/Command/MessageSenderCommand.php
@@ -6,7 +6,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Swarrot\Broker\Message;
 
 class MessageSenderCommand extends BaseCommand
 {

--- a/src/Bab/RabbitMq/Configuration.php
+++ b/src/Bab/RabbitMq/Configuration.php
@@ -4,9 +4,18 @@ namespace Bab\RabbitMq;
 
 interface Configuration extends \ArrayAccess
 {
+    /**
+     * @return string
+     */
     public function getVhost();
 
+    /**
+     * @return bool
+     */
     public function hasDeadLetterExchange();
 
+    /**
+     * @return bool
+     */
     public function hasUnroutableExchange();
 }

--- a/src/Bab/RabbitMq/HttpClient.php
+++ b/src/Bab/RabbitMq/HttpClient.php
@@ -4,7 +4,12 @@ namespace Bab\RabbitMq;
 
 interface HttpClient
 {
-    public function __construct($host, $port, $user, $pass);
-
+    /**
+     * @param string     $verb
+     * @param string     $uri
+     * @param array|null $parameters
+     *
+     * @return string response body
+     */
     public function query($verb, $uri, array $parameters = null);
 }

--- a/src/Bab/RabbitMq/HttpClient/CurlClient.php
+++ b/src/Bab/RabbitMq/HttpClient/CurlClient.php
@@ -19,6 +19,9 @@ class CurlClient implements HttpClient
         $this->pass = $pass;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function query($verb, $uri, array $parameters = null)
     {
         $handle = $this->getHandle();

--- a/src/Bab/RabbitMq/VhostManager.php
+++ b/src/Bab/RabbitMq/VhostManager.php
@@ -11,7 +11,6 @@ class VhostManager
 
     protected $credentials;
     private $httpClient;
-    private $config;
 
     public function __construct(array $credentials, Action $action, HttpClient $httpClient)
     {
@@ -27,7 +26,7 @@ class VhostManager
     }
 
     /**
-     * resetVhost
+     * Resets vhost
      *
      * @return void
      */
@@ -55,9 +54,9 @@ class VhostManager
     }
 
     /**
-     * createMapping
+     * Creates mapping
      *
-     * @param array $config
+     * @param Configuration $config
      *
      * @return void
      */
@@ -295,7 +294,7 @@ class VhostManager
      */
     public function remove($queue)
     {
-        return $this->query('DELETE', '/api/queues/'.$this->credentials['vhost'].'/'.$queue);
+        $this->query('DELETE', '/api/queues/'.$this->credentials['vhost'].'/'.$queue);
     }
 
     /**
@@ -307,7 +306,7 @@ class VhostManager
      */
     public function purge($queue)
     {
-        return $this->query('DELETE', '/api/queues/'.$this->credentials['vhost'].'/'.$queue.'/contents');
+        $this->query('DELETE', '/api/queues/'.$this->credentials['vhost'].'/'.$queue.'/contents');
     }
 
     /**
@@ -320,7 +319,7 @@ class VhostManager
      */
     protected function createExchange($exchange, array $parameters = array())
     {
-        return $this->action->createExchange($exchange, $parameters);
+        $this->action->createExchange($exchange, $parameters);
     }
 
     /**
@@ -333,7 +332,7 @@ class VhostManager
      */
     protected function createQueue($queue, array $parameters = array())
     {
-        return $this->action->createQueue($queue, $parameters);
+        $this->action->createQueue($queue, $parameters);
     }
 
     /**
@@ -347,7 +346,7 @@ class VhostManager
      */
     protected function createBinding($exchange, $queue, $routingKey = null, array $arguments = array())
     {
-        return $this->action->createBinding($exchange, $queue, $routingKey, $arguments);
+        $this->action->createBinding($exchange, $queue, $routingKey, $arguments);
     }
 
     /**
@@ -375,7 +374,7 @@ class VhostManager
      */
     protected function createDl()
     {
-        return $this->createExchange('dl', array(
+        $this->createExchange('dl', array(
             'type'      => 'direct',
             'durable'   => true,
             'arguments' => array(
@@ -387,7 +386,7 @@ class VhostManager
     /**
      * setPermissions
      *
-     * @param array $permissions
+     * @param Configuration $config
      *
      * @return void
      */
@@ -406,7 +405,7 @@ class VhostManager
      *
      * @param array $userPermissions
      *
-     * @return void
+     * @return array
      */
     private function extractPermissions(array $userPermissions = array())
     {
@@ -430,11 +429,11 @@ class VhostManager
     /**
      * query
      *
-     * @param mixed $method
-     * @param mixed $url
-     * @param array $parameters
+     * @param string $method
+     * @param string $url
+     * @param array|null $parameters
      *
-     * @return response body
+     * @return string response body
      */
     protected function query($method, $url, array $parameters = null)
     {


### PR DESCRIPTION
- add phpdoc on interfaces to document the argument and return types
- remove constructors from interfaces as they are not relevant (classes relying on the interfaces are using DI and so don't care about the constructor)
- avoid returning the API response body in methods meant to return nothing (half of methods were doing it)
- remove unused use statements and property
