### PR TITLE
Fix the support for Symfony 3 and the exit code of message:sender

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.4",
-        "symfony/console": "^2.4|^3.0",
+        "symfony/console": "^2.7|^3.0",
         "symfony/yaml": "^2.4|^3.0",
         "swarrot/swarrot": "~2.0"
     },

--- a/src/Bab/RabbitMq/Command/BaseCommand.php
+++ b/src/Bab/RabbitMq/Command/BaseCommand.php
@@ -91,15 +91,10 @@ class BaseCommand extends Command
         if ($input->hasParameterOption(['--password', '-p'])) {
             $credentials['password'] = $input->getOption('password');
         } elseif (null === $input->getOption('password')) {
-            $questionHelper = $this->getHelperSet()->has('question') ? $this->getHelperSet()->get('question') : $this->getHelperSet()->get('dialog');
-            $question = '<question>Password?</question>';
+            $question = new Question('<question>Password?</question>');
+            $question->setHidden(true);
 
-            if ($questionHelper instanceof QuestionHelper) {
-                $question = new Question($question);
-                $question->setHidden(true);
-            }
-
-            $credentials['password'] = $questionHelper->ask($input, $output, $question);
+            $credentials['password'] = $this->getHelperSet()->get('question')->ask($input, $output, $question);
         }
 
         return $credentials;

--- a/src/Bab/RabbitMq/Command/MessageSenderCommand.php
+++ b/src/Bab/RabbitMq/Command/MessageSenderCommand.php
@@ -2,6 +2,7 @@
 
 namespace Bab\RabbitMq\Command;
 
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
@@ -84,12 +85,14 @@ class MessageSenderCommand extends BaseCommand
         if (count($notHandledMessages)) {
             $output->writeln(sprintf('<error>- %d message(s) were/was not published into rabbit:</error>', count($notHandledMessages)));
 
-            $tableHelper = $this->getHelperSet()->get('table');
-            $tableHelper
+            $table = new Table($output);
+            $table
                 ->setHeaders(array('Message', 'Exception'))
                 ->setRows($notHandledMessages)
             ;
-            $tableHelper->render($output);
+            $table->render();
+
+            return 1;
         }
     }
 }


### PR DESCRIPTION
The TableHelper is gone in Symfony 3.

Note that instead of keeping usage of the old API for Symfony <2.6, I decided to bump the symfony/console requirement to 2.7 (and so I simplified the other place doing such support for pre-2.6 versions).
The version 2.4, 2.5 and 2.5 (which are excluded by my change) are unmaintained since years.

I also added the proper exit code in ``message:sender`` when some messages are failing