### PR TITLE
Moved creation of retry exchange outisde of loop

### DIFF
--- a/src/Bab/RabbitMq/Specification/DeadLetterExchangeCanBeCreated.php
+++ b/src/Bab/RabbitMq/Specification/DeadLetterExchangeCanBeCreated.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Bab\RabbitMq\Specification;
+
+class DeadLetterExchangeCanBeCreated implements Specification
+{
+    public function isSatisfiedBy($config)
+    {
+        if ($config->hasDeadLetterExchange() === true) {
+            return true;
+        }
+
+        if (!isset($config['queues']) || 0 === count($config['queues'])) {
+            return false;
+        }
+
+        $currentWithDl = false;
+        foreach ($config['queues'] as $name => $parameters) {
+            if (isset($parameters['with_dl']) && true === (bool) $parameters['with_dl']) {
+                return true;
+            }
+
+            if (isset($parameters['retries'])) {
+                return true;
+            }
+
+            if ($currentWithDl) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Bab/RabbitMq/Specification/DelayExchangeCanBeCreated.php
+++ b/src/Bab/RabbitMq/Specification/DelayExchangeCanBeCreated.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Bab\RabbitMq\Specification;
+
+class DelayExchangeCanBeCreated implements Specification
+{
+    public function isSatisfiedBy($config)
+    {
+        if (!isset($config['queues']) || 0 === count($config['queues'])) {
+            return false;
+        }
+
+        foreach ($config['queues'] as $name => $parameters) {
+            if (isset($parameters['delay'])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Bab/RabbitMq/Specification/RetryExchangeCanBeCreated.php
+++ b/src/Bab/RabbitMq/Specification/RetryExchangeCanBeCreated.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Bab\RabbitMq\Specification;
+
+class RetryExchangeCanBeCreated implements Specification
+{
+    public function isSatisfiedBy($config)
+    {
+        if (!isset($config['queues']) || 0 === count($config['queues'])) {
+            return false;
+        }
+
+        foreach ($config['queues'] as $name => $parameters) {
+            if (isset($parameters['retries'])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Bab/RabbitMq/Specification/Specification.php
+++ b/src/Bab/RabbitMq/Specification/Specification.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Bab\RabbitMq\Specification;
+
+interface Specification
+{
+    /**
+     * @param $candidate
+     *
+     * @return bool
+     */
+    public function isSatisfiedBy($candidate);
+}

--- a/tests/Bab/RabbitMQ/Specification/DeadLetterExchangeCanBeCreatedTest.php
+++ b/tests/Bab/RabbitMQ/Specification/DeadLetterExchangeCanBeCreatedTest.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Bab\RabbitMq;
+
+use Bab\RabbitMq\Specification\DeadLetterExchangeCanBeCreated;
+
+class DeadLetterExchangeCanBeCreatedTest extends \PHPUnit_Framework_TestCase
+{
+    private $specification;
+
+    public function setUp()
+    {
+        $this->specification = new DeadLetterExchangeCanBeCreated();
+    }
+
+    /**
+     * @param $expected
+     * @param array $arrayConfig
+     *
+     * @dataProvider provideConfig
+     */
+    public function testItCreatesAnExchange($expected, array $arrayConfig)
+    {
+        $config = new Configuration\FromArray($arrayConfig);
+        $this->assertEquals($expected, $this->specification->isSatisfiedBy($config));
+    }
+
+    public function provideConfig()
+    {
+        return [
+            [
+                false,
+                [
+                    'my_vhost' => [
+                        'parameters' => [
+                            'with_dl' => false,
+                            'with_unroutable' => false,
+                        ],
+                        'exchanges' => [
+                            'default' => ['type' => 'direct', 'durable' => true],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                true,
+                [
+                    'my_vhost' => [
+                        'parameters' => [
+                            'with_dl' => false,
+                            'with_unroutable' => false,
+                        ],
+                        'exchanges' => [
+                            'default' => ['type' => 'direct', 'durable' => true],
+                        ],
+                        'queues' => [
+                            'test_queue' => [
+                                'durable' => true,
+                                'retries' => [5, 10, 15],
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                true,
+                [
+                    'my_vhost' => [
+                        'parameters' => [
+                            'with_dl' => true,
+                            'with_unroutable' => false,
+                        ],
+                        'exchanges' => [
+                            'default' => ['type' => 'direct', 'durable' => true],
+                        ],
+                        'queues' => [
+                            'test_queue' => [
+                                'durable' => true,
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                true,
+                [
+                    'my_vhost' => [
+                        'parameters' => [
+                            'with_dl' => false,
+                            'with_unroutable' => false,
+                        ],
+                        'exchanges' => [
+                            'default' => ['type' => 'direct', 'durable' => true],
+                        ],
+                        'queues' => [
+                            'test_queue' => [
+                                'with_dl' => true,
+                                'durable' => true,
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                false,
+                [
+                    'my_vhost' => [
+                        'parameters' => [
+                            'with_dl' => false,
+                            'with_unroutable' => false,
+                        ],
+                        'exchanges' => [
+                            'default' => ['type' => 'direct', 'durable' => true],
+                        ],
+                        'queues' => [
+                            'test_queue' => [
+                                'durable' => true,
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                true,
+                [
+                    'my_vhost' => [
+                        'parameters' => [
+                            'with_dl' => false,
+                            'with_unroutable' => false,
+                        ],
+                        'exchanges' => [
+                            'default' => ['type' => 'direct', 'durable' => true],
+                        ],
+                        'queues' => [
+                            'test_queue' => [
+                                'durable' => true,
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue'],
+                                ],
+                            ],
+                            'test_queue_2' => [
+                                'durable' => true,
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue_2'],
+                                ],
+                            ],
+                            'test_queue_with_retry' => [
+                                'durable' => true,
+                                'retries' => [10],
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue_with_retry'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                true,
+                [
+                    'my_vhost' => [
+                        'parameters' => [
+                            'with_dl' => false,
+                            'with_unroutable' => false,
+                        ],
+                        'exchanges' => [
+                            'default' => ['type' => 'direct', 'durable' => true],
+                        ],
+                        'queues' => [
+                            'test_queue' => [
+                                'durable' => true,
+                                'with_dl' => false,
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue'],
+                                ],
+                            ],
+                            'test_queue_2' => [
+                                'durable' => true,
+                                'with_dl' => false,
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue_2'],
+                                ],
+                            ],
+                            'test_queue_with_retry' => [
+                                'durable' => true,
+                                'with_dl' => true,
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue_with_retry'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Bab/RabbitMQ/Specification/DelayExchangeCanBeCreatedTest.php
+++ b/tests/Bab/RabbitMQ/Specification/DelayExchangeCanBeCreatedTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Bab\RabbitMq;
+
+use Bab\RabbitMq\Specification\DelayExchangeCanBeCreated;
+
+class DelayExchangeCanBeCreatedTest extends \PHPUnit_Framework_TestCase
+{
+    private $specification;
+
+    public function setUp()
+    {
+        $this->specification = new DelayExchangeCanBeCreated();
+    }
+
+    /**
+     * @param $expected
+     * @param array $arrayConfig
+     *
+     * @dataProvider provideConfig
+     */
+    public function testItCreatesAnExchange($expected, array $arrayConfig)
+    {
+        $config = new Configuration\FromArray($arrayConfig);
+        $this->assertEquals($expected, $this->specification->isSatisfiedBy($config));
+    }
+
+    public function provideConfig()
+    {
+        return [
+            [
+                false,
+                [
+                    'my_vhost' => [
+                        'parameters' => [
+                            'with_dl' => false,
+                            'with_unroutable' => false,
+                        ],
+                        'exchanges' => [
+                            'default' => ['type' => 'direct', 'durable' => true],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                false,
+                [
+                    'my_vhost' => [
+                        'parameters' => [
+                            'with_dl' => false,
+                            'with_unroutable' => false,
+                        ],
+                        'exchanges' => [
+                            'default' => ['type' => 'direct', 'durable' => true],
+                        ],
+                        'queues' => [
+                            'test_queue' => [
+                                'durable' => true,
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                true,
+                [
+                    'my_vhost' => [
+                        'parameters' => [
+                            'with_dl' => false,
+                            'with_unroutable' => false,
+                        ],
+                        'exchanges' => [
+                            'default' => ['type' => 'direct', 'durable' => true],
+                        ],
+                        'queues' => [
+                            'test_queue' => [
+                                'durable' => true,
+                                'delay' => 4,
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                true,
+                [
+                    'my_vhost' => [
+                        'parameters' => [
+                            'with_dl' => false,
+                            'with_unroutable' => false,
+                        ],
+                        'exchanges' => [
+                            'default' => ['type' => 'direct', 'durable' => true],
+                        ],
+                        'queues' => [
+                            'test_queue' => [
+                                'durable' => true,
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue'],
+                                ],
+                            ],
+                            'test_queue_2' => [
+                                'durable' => true,
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue_2'],
+                                ],
+                            ],
+                            'test_queue_with_retry' => [
+                                'durable' => true,
+                                'delay' => 8,
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue_with_retry'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                false,
+                [
+                    'my_vhost' => [
+                        'parameters' => [
+                            'with_dl' => false,
+                            'with_unroutable' => false,
+                        ],
+                        'exchanges' => [
+                            'default' => ['type' => 'direct', 'durable' => true],
+                        ],
+                        'queues' => [
+                            'test_queue' => [
+                                'durable' => true,
+                                'with_dl' => false,
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue'],
+                                ],
+                            ],
+                            'test_queue_2' => [
+                                'durable' => true,
+                                'with_dl' => false,
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue_2'],
+                                ],
+                            ],
+                            'test_queue_with_retry' => [
+                                'durable' => true,
+                                'with_dl' => true,
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue_with_retry'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Bab/RabbitMQ/Specification/RetryExchangeCanBeCreatedTest.php
+++ b/tests/Bab/RabbitMQ/Specification/RetryExchangeCanBeCreatedTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Bab\RabbitMq;
+
+use Bab\RabbitMq\Specification\RetryExchangeCanBeCreated;
+
+class RetryExchangeCanBeCreatedTest extends \PHPUnit_Framework_TestCase
+{
+    private $specification;
+
+    public function setUp()
+    {
+        $this->specification = new RetryExchangeCanBeCreated();
+    }
+
+    /**
+     * @param $expected
+     * @param array $arrayConfig
+     *
+     * @dataProvider provideConfig
+     */
+    public function testItCreatesAnExchange($expected, array $arrayConfig)
+    {
+        $config = new Configuration\FromArray($arrayConfig);
+        $this->assertEquals($expected, $this->specification->isSatisfiedBy($config));
+    }
+
+    public function provideConfig()
+    {
+        return [
+            [
+                false,
+                [
+                    'my_vhost' => [
+                        'parameters' => [
+                            'with_dl' => false,
+                            'with_unroutable' => false,
+                        ],
+                        'exchanges' => [
+                            'default' => ['type' => 'direct', 'durable' => true],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                true,
+                [
+                    'my_vhost' => [
+                        'parameters' => [
+                            'with_dl' => false,
+                            'with_unroutable' => false,
+                        ],
+                        'exchanges' => [
+                            'default' => ['type' => 'direct', 'durable' => true],
+                        ],
+                        'queues' => [
+                            'test_queue' => [
+                                'durable' => true,
+                                'retries' => [5, 10, 15],
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                false,
+                [
+                    'my_vhost' => [
+                        'parameters' => [
+                            'with_dl' => false,
+                            'with_unroutable' => false,
+                        ],
+                        'exchanges' => [
+                            'default' => ['type' => 'direct', 'durable' => true],
+                        ],
+                        'queues' => [
+                            'test_queue' => [
+                                'durable' => true,
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                true,
+                [
+                    'my_vhost' => [
+                        'parameters' => [
+                            'with_dl' => false,
+                            'with_unroutable' => false,
+                        ],
+                        'exchanges' => [
+                            'default' => ['type' => 'direct', 'durable' => true],
+                        ],
+                        'queues' => [
+                            'test_queue' => [
+                                'durable' => true,
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue'],
+                                ],
+                            ],
+                            'test_queue_2' => [
+                                'durable' => true,
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue_2'],
+                                ],
+                            ],
+                            'test_queue_with_retry' => [
+                                'durable' => true,
+                                'retries' => [10],
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue_with_retry'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                false,
+                [
+                    'my_vhost' => [
+                        'parameters' => [
+                            'with_dl' => false,
+                            'with_unroutable' => false,
+                        ],
+                        'exchanges' => [
+                            'default' => ['type' => 'direct', 'durable' => true],
+                        ],
+                        'queues' => [
+                            'test_queue' => [
+                                'durable' => true,
+                                'with_dl' => false,
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue'],
+                                ],
+                            ],
+                            'test_queue_2' => [
+                                'durable' => true,
+                                'with_dl' => false,
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue_2'],
+                                ],
+                            ],
+                            'test_queue_with_retry' => [
+                                'durable' => true,
+                                'with_dl' => true,
+                                'bindings' => [
+                                    ['exchange' => 'default', 'routing_key' => 'test_queue_with_retry'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Hi,

I'm currently taking a look at the retry configuration of this lib. I've noticed that the creation of the _retry_ exchange is done as many times as the creation of _retry_ queues. Here is a output of my last command for instance : 
```shell
vendor/bin/rabbit vhost:mapping:create default_vhost.yml --host=127.0.0.1 --port=8080
Password?
With DL: false
With Unroutable: false
Create exchange default
Create exchange dl
Create queue send_email
Create queue send_email_dl
Create binding between exchange dl and queue send_email_dl (with routing_key: send_email)
Create exchange retry
Create queue send_email_retry_1
Create binding between exchange retry and queue send_email_retry_1 (with routing_key: send_email_retry_1)
Create binding between exchange retry and queue send_email (with routing_key: send_email)
Create exchange retry
Create queue send_email_retry_2
Create binding between exchange retry and queue send_email_retry_2 (with routing_key: send_email_retry_2)
Create binding between exchange retry and queue send_email (with routing_key: send_email)
Create exchange retry
Create queue send_email_retry_3
Create binding between exchange retry and queue send_email_retry_3 (with routing_key: send_email_retry_3)
Create binding between exchange retry and queue send_email (with routing_key: send_email)
Create binding between exchange default and queue send_email (with routing_key: send_email)
``` 
You can clearly see that `Create exchange retry` appears 3 times, and that binding is also made 3 times. 

I really hope I'm not missing anything here, so here is a PR to fix this.
