### PR TITLE
Use Swarrot to publish messages

### DIFF
--- a/src/Bab/RabbitMq/VhostManager.php
+++ b/src/Bab/RabbitMq/VhostManager.php
@@ -271,9 +271,13 @@ class VhostManager
      * @param string $message
      *
      * @throws \RuntimeException if an error occured during the publication
+     *
+     * @deprecated
      */
     public function publishMessage($exchangeName, $routingKey, $message)
     {
+        @trigger_error('Sending messages using the VhostManager is deprecated. Use Swarrot instead, which has better performance when sending multiple messages.', E_USER_DEPRECATED);
+
         $informations = $this->query('POST', sprintf(
             '/api/exchanges/%s/%s/publish',
             $this->credentials['vhost'],


### PR DESCRIPTION
Using the AMQP protocol is a lot faster than sending one POST request per message when sending messages in batch (by using a file in the message:sender command).

This is something I have since a very long time locally, when I became frustrated when sending big batches of messages with the toolkit.

As the VhostManager is not marked as `@internal`, I decided to keep the `VhostManager::publishMessage` method for now to avoid BC break, deprecating it instead (as the toolkit itself does not use it anymore). 