### PR TITLE
Fix the travis setup for rabbitmq

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ php:
   - 7.1
   - 7.2
 
+addons:
+    apt:
+        packages:
+            - rabbitmq-server
+
 services:
     - rabbitmq
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: php
 
 php:
@@ -15,7 +13,7 @@ services:
     - rabbitmq
 
 before_install:
-    - rabbitmq-plugins enable rabbitmq_management
+    - sudo rabbitmq-plugins enable rabbitmq_management
     - composer self-update --stable --no-interaction
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ services:
     - rabbitmq
 
 before_install:
+    - rabbitmq-plugins enable rabbitmq_management
     - composer self-update --stable --no-interaction
 
 before_script:


### PR DESCRIPTION
The rabbitmq-server package is not preinstalled on Xenial anymore.