### PR TITLE
Add #[ReturnTypeWillChange] attribute for FromArray::offsetGet

### DIFF
--- a/src/Bab/RabbitMq/Configuration/FromArray.php
+++ b/src/Bab/RabbitMq/Configuration/FromArray.php
@@ -67,6 +67,7 @@ class FromArray implements Configuration
     /**
      * {@inheritdoc}
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->config[$offset]) ? $this->config[$offset] : null;


### PR DESCRIPTION
@odolbeau Hi! I need to temporarily suppress the notice that the latest implementation of FromArray class causes on my production. Is it ok If I make such a pr for you? I am using your package in a lot of places and such a warning is converted to ErrorException which is a bit inconvenient for my current production setup.